### PR TITLE
Fix gesture haptic feedback setting.

### DIFF
--- a/configpanel/res/xml/touchscreen_panel.xml
+++ b/configpanel/res/xml/touchscreen_panel.xml
@@ -34,7 +34,8 @@
     <PreferenceCategory android:title="@string/touchscreen_extras">
 
         <SwitchPreference
-            android:key="touchscreen_haptic_feedback"
+            android:key="touchscreen_gesture_haptic_feedback"
+            android:persistent="false"
             android:title="@string/haptic_feedback"
             android:summary="@string/haptic_feedback_summary" />
 

--- a/configpanel/src/com/cyanogenmod/settings/device/TouchscreenGestureSettings.java
+++ b/configpanel/src/com/cyanogenmod/settings/device/TouchscreenGestureSettings.java
@@ -21,25 +21,22 @@ import com.android.internal.util.cm.ScreenType;
 import com.cyanogenmod.settings.device.utils.NodePreferenceActivity;
 
 import android.os.Bundle;
-import android.os.SystemProperties;
+import android.provider.Settings;
 import android.preference.Preference;
 import android.preference.SwitchPreference;
 
 public class TouchscreenGestureSettings extends NodePreferenceActivity {
+    private static final String KEY_HAPTIC_FEEDBACK = "touchscreen_gesture_haptic_feedback";
 
-    private static final String KEY_HAPTIC_FEEDBACK = "touchscreen_haptic_feedback";
-
-    private static final String PROP_HAPTIC_FEEDBACK = "persist.gestures.haptic";
+    private SwitchPreference mHapticFeedback;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.touchscreen_panel);
 
-        final SwitchPreference hapticFeedback =
-                (SwitchPreference) findPreference(KEY_HAPTIC_FEEDBACK);
-        hapticFeedback.setChecked(SystemProperties.getBoolean(PROP_HAPTIC_FEEDBACK, true));
-        hapticFeedback.setOnPreferenceChangeListener(this);
+        mHapticFeedback = (SwitchPreference) findPreference(KEY_HAPTIC_FEEDBACK);
+        mHapticFeedback.setOnPreferenceChangeListener(this);
     }
 
     @Override
@@ -47,6 +44,7 @@ public class TouchscreenGestureSettings extends NodePreferenceActivity {
         final String key = preference.getKey();
         if (KEY_HAPTIC_FEEDBACK.equals(key)) {
             final boolean value = (Boolean) newValue;
+            Settings.System.putInt(getContentResolver(), KEY_HAPTIC_FEEDBACK, value ? 1 : 0);
             return true;
         }
 
@@ -61,6 +59,8 @@ public class TouchscreenGestureSettings extends NodePreferenceActivity {
         if (!ScreenType.isTablet(this)) {
             getListView().setPadding(0, 0, 0, 0);
         }
-    }
 
+        mHapticFeedback.setChecked(
+                Settings.System.getInt(getContentResolver(), KEY_HAPTIC_FEEDBACK, 1) != 0);
+    }
 }

--- a/keyhandler/src/com/cyanogenmod/settings/device/KeyHandler.java
+++ b/keyhandler/src/com/cyanogenmod/settings/device/KeyHandler.java
@@ -37,7 +37,6 @@ import android.os.PowerManager.WakeLock;
 import android.os.RemoteException;
 import android.os.ServiceManager;
 import android.os.SystemClock;
-import android.os.SystemProperties;
 import android.os.UserHandle;
 import android.os.Vibrator;
 import android.provider.MediaStore;
@@ -54,7 +53,8 @@ public class KeyHandler implements DeviceKeyHandler {
     private static final String TAG = KeyHandler.class.getSimpleName();
     private static final int GESTURE_REQUEST = 1;
 
-    private static final String PROP_HAPTIC_FEEDBACK = "persist.gestures.haptic";
+    private static final String KEY_GESTURE_HAPTIC_FEEDBACK =
+            "touchscreen_gesture_haptic_feedback";
 
     private static final String ACTION_DISMISS_KEYGUARD =
             "com.android.keyguard.action.DISMISS_KEYGUARD_SECURELY";
@@ -263,7 +263,13 @@ public class KeyHandler implements DeviceKeyHandler {
     }
 
     private void doHapticFeedback() {
-        if (mVibrator == null || !SystemProperties.getBoolean(PROP_HAPTIC_FEEDBACK, true)) return;
-        mVibrator.vibrate(50);
+        if (mVibrator == null) {
+            return;
+        }
+        boolean enabled = Settings.System.getInt(mContext.getContentResolver(),
+                KEY_GESTURE_HAPTIC_FEEDBACK, 1) != 0;
+        if (enabled) {
+            mVibrator.vibrate(50);
+        }
     }
 }


### PR DESCRIPTION
The setting value was read from a system property, but never written. As
using a system property has SELinux implications and updating the
policies for all devices is more trouble than it's worth, the code was
changed to use a system setting instead.

Change-Id: I63be2e41a5a02bf537dbc3ad422282db296dd099